### PR TITLE
Convert line breaks to paragraph breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ description
 Notes on the formatting:
 * Use `**bold**` for section header
 * Section headers do not need a trailing colon
-* Use double-spaces at the end of a line to make a line-break
-* Use two line-break to start a new paragraph in text or after the section headers
+* ~~Use double-spaces at the end of a line to make a line-break~~ Appstream parser removes whitespaces. 
+* Use two line breaks to start a new paragraph in text or after the section headers
 * URLs get converted to hyperlinks automatically. Adding hyperlinks as `[title](url)` work on Github and in the snapcraft.io preview but will not be rendered on the final snapcraft.io listing!
 
 

--- a/metadata/edgex-app-service-configurable.md
+++ b/metadata/edgex-app-service-configurable.md
@@ -3,19 +3,24 @@ EdgeX App Service Configurable
 This service is provided as an easy way to get started with processing data flowing through EdgeX.
 It leverages the App Functions SDK and provides a way for developers to use configuration instead of writing code to utilize the built-in functionalities.
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/app-service-configurable/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/app-service-configurable
 
-**Service usage examples**  
+**Service usage examples**
+
 * v1.3: https://docs.edgexfoundry.org/1.3/microservices/application/AppServiceConfigurable
 * v2.1: https://docs.edgexfoundry.org/2.1/microservices/application/AppServiceConfigurable
 * v2.2: https://docs.edgexfoundry.org/2.2/microservices/application/AppServiceConfigurable
 
-**EdgeX Documentation**  
+**EdgeX Documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-cli.md
+++ b/metadata/edgex-cli.md
@@ -4,19 +4,24 @@ EdgeX CLI is a command-line interface tool for developers, used for interacting 
 
 For a graphical user interface, see https://snapcraft.io/edgex-ui
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/edgex-cli/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/edgex-cli
 
-**Getting started**  
+**Getting started**
+
 * v1.3: https://docs.edgexfoundry.org/1.3/getting-started/tools/Ch-CommandLineInterface
 * v2.1: https://docs.edgexfoundry.org/2.1/getting-started/tools/Ch-CommandLineInterface
 * v2.2: https://docs.edgexfoundry.org/2.2/getting-started/tools/Ch-CommandLineInterface
 
-**EdgeX Documentation**  
+**EdgeX Documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-device-camera.md
+++ b/metadata/edgex-device-camera.md
@@ -3,14 +3,18 @@ EdgeX Device Camera
 The EdgeX Device Camera is a device service for communicating with ONVIF-compliant cameras via EdgeX.
 It can be used to get and set camera attributes and retrieve snapshot images.
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/device-camera-go/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/device-camera-go
 
-**EdgeX documentation**  
+**EdgeX documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-device-gpio.md
+++ b/metadata/edgex-device-gpio.md
@@ -3,19 +3,21 @@ EdgeX Device GPIO
 EdgeX Device GPIO is a device service for connecting GPIO devices to EdgeX.
 
 ** Functionality **
-* This device service uses sysfs ABI (default) or chardev ABI (experiment) 
-  to control GPIO devices For a connected GPIO device, update the configuration files, 
-  and then start to read or write data from GPIO device
+* This device service uses sysfs ABI (default) or chardev ABI (experiment) to control GPIO devices For a connected GPIO device, update the configuration files, and then start to read or write data from GPIO device
 * This device service ONLY works on Linux system
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/device-gpio/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/device-gpio
 
-**EdgeX documentation**  
+**EdgeX documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-device-grove.md
+++ b/metadata/edgex-device-grove.md
@@ -7,11 +7,14 @@ This device service is expected to work on the following boards:
 * Raspberry Pi 3 or higher - arm64 OS
 * Raspberry Pi Zero 2 or higher - arm64 OS (untested)
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/device-grove-c
 
-**EdgeX documentation**  
+**EdgeX documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-device-modbus.md
+++ b/metadata/edgex-device-modbus.md
@@ -3,19 +3,24 @@ EdgeX Device Modbus
 EdgeX Device Modbus is a device service for adding Modbus communication capabilities to EdgeX.
 It supports read/write over both Modbus TCP and Modbus RTU protocols.
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/device-modbus-go/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/device-modbus-go
 
-**Service usage examples**  
+**Service usage examples**
+
 * v1.3: https://docs.edgexfoundry.org/1.3/examples/Ch-ExamplesAddingModbusDevice
 * v2.1: https://docs.edgexfoundry.org/2.1/examples/Ch-ExamplesAddingModbusDevice
 * v2.2: https://docs.edgexfoundry.org/2.2/examples/Ch-ExamplesAddingModbusDevice
 
-**EdgeX documentation**  
+**EdgeX documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-device-mqtt.md
+++ b/metadata/edgex-device-mqtt.md
@@ -4,19 +4,24 @@ EdgeX Device MQTT is a device service for connecting an MQTT Broker to EdgeX.
 The service acts as a device which can send data or receive and respond to commands
 by publishing and subscribing to MQTT topics.
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/device-mqtt-go/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/device-mqtt-go
 
-**Service usage examples**  
+**Service usage examples**
+
 * v1.3: https://docs.edgexfoundry.org/1.3/examples/Ch-ExamplesAddingMQTTDevice
 * v2.1: https://docs.edgexfoundry.org/2.1/examples/Ch-ExamplesAddingMQTTDevice
 * v2.2: https://docs.edgexfoundry.org/2.2/examples/Ch-ExamplesAddingMQTTDevice
 
-**EdgeX documentation**  
+**EdgeX documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-device-rest.md
+++ b/metadata/edgex-device-rest.md
@@ -2,14 +2,18 @@ EdgeX Device REST
 ---
 EdgeX Device REST is a device service which exposes RESTful endpoints for applications to push data into EdgeX over HTTP. This is useful for a variety of 3rd applications such as Point of Sale and CV Analytics allowing textual or binary data ingestion into EdgeX.
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/device-rest-go/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/device-rest-go
 
-**EdgeX documentation**  
+**EdgeX documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-device-snmp.md
+++ b/metadata/edgex-device-snmp.md
@@ -7,19 +7,24 @@ This enables both reading and writing data to a devices over the SNMP protocol.
 This device service is currently tailored specifically to:
 * TrendNET TEG-082WS Switch
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/device-snmp-go/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/device-snmp-go
 
-**Service usage examples**  
+**Service usage examples**
+
 * v1.3: https://docs.edgexfoundry.org/1.3/examples/Ch-ExamplesAddingSNMPDevice
 * v2.1: https://docs.edgexfoundry.org/2.1/examples/Ch-ExamplesAddingSNMPDevice
 * v2.2: https://docs.edgexfoundry.org/2.2/examples/Ch-ExamplesAddingSNMPDevice
 
-**EdgeX documentation**  
+**EdgeX documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgex-ui.md
+++ b/metadata/edgex-ui.md
@@ -6,18 +6,23 @@ single instance of EdgeX Foundry.
 
 For a command-line interface, see https://snapcraft.io/edgex-cli
 
-**Snap usage instructions**  
+**Snap usage instructions**
+
 https://github.com/edgexfoundry/edgex-ui-go/blob/main/snap/README.md
 
-**Source code and more info**  
+**Source code and more info**
+
 https://github.com/edgexfoundry/edgex-ui-go
 
-**Getting started**  
+**Getting started**
+
 * v2.1: https://docs.edgexfoundry.org/2.1/getting-started/tools/Ch-GUI
 * v2.2: https://docs.edgexfoundry.org/2.2/getting-started/tools/Ch-GUI
 
-**EdgeX Documentation**  
+**EdgeX Documentation**
+
 https://docs.edgexfoundry.org
 
-**Reference platform snap**  
+**Reference platform snap**
+
 https://snapcraft.io/edgexfoundry

--- a/metadata/edgexfoundry.md
+++ b/metadata/edgexfoundry.md
@@ -35,18 +35,10 @@ Note that not all the above services are enabled and started by default.
 =============
 
 **Further Reading**
-
-Getting started with snaps (v2.1)  
-https://docs.edgexfoundry.org/2.1/getting-started/Ch-GettingStartedSnapUsers
-
-Snap usage instructions  
-https://github.com/edgexfoundry/edgex-go/blob/main/snap/README.md
-
-EdgeX documentation  
-https://docs.edgexfoundry.org
-
-Source code  
-https://github.com/edgexfoundry/edgex-go
+* Getting started with snaps (v2.1): https://docs.edgexfoundry.org/2.1/getting-started/Ch-GettingStartedSnapUsers
+* Snap usage instructions: https://github.com/edgexfoundry/edgex-go/blob/main/snap/README.md
+* EdgeX documentation: https://docs.edgexfoundry.org
+* Source code: https://github.com/edgexfoundry/edgex-go
 
 ====================
 


### PR DESCRIPTION
The appstream parser removes trailing white spaces from each line (see [code](https://github.com/snapcore/snapcraft/blob/383c1f1ce48778916a13f361f01d8badd5b9e406/snapcraft/extractors/appstream.py#L154)). As a result, the trailing double-spaces used to create a line break in markdown get removed.

This PR replaces those double-spaces with a markdown paragraph breaks, i.e. two consecutive line breaks.

In one case, the style is changed to use bullet points instead.